### PR TITLE
Avoid alias problem in PowerShell on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ curl -o textnote -L https://github.com/dkaslovsky/textnote/releases/latest/dow
 
 Windows
 ```
-$ curl -o textnote -L https://github.com/dkaslovsky/textnote/releases/latest/download/textnote_windows_amd64.exe
+> curl.exe -o textnote -L https://github.com/dkaslovsky/textnote/releases/latest/download/textnote_windows_amd64.exe
 ```
 
 ### Installing from source

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ curl -o textnote -L https://github.com/dkaslovsky/textnote/releases/latest/dow
 
 Windows
 ```
-> curl.exe -o textnote -L https://github.com/dkaslovsky/textnote/releases/latest/download/textnote_windows_amd64.exe
+> curl.exe -o textnote.exe -L https://github.com/dkaslovsky/textnote/releases/latest/download/textnote_windows_amd64.exe
 ```
 
 ### Installing from source


### PR DESCRIPTION
`curl` is an alias for `Invoke-WebRequest` in PowerShell 5 on Windows, so specifying the file extension allows `curl` to run regardless.