### PR TITLE
Use $EDITOR to open notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All note files are stored locally on the file system in a single directory.
 Notes can easily be synced to a remote server or cloud service if so desired by ensuring the application directory is remotely synced.
 
 textnote opens notes using the text editor specified by the environment variable `$EDITOR` and defaults to Vim if the environment variable is not set.
-See [Configuration](#configuration) for more details. 
+See the [Editor-Specific Configuration](#editor-specific-configuration) subsection for more details. 
 
 ## Quick Start
 1. Install textnote (see [Installation](#installation))
@@ -303,14 +303,6 @@ cli:
   timeFormat: "2006-01-02"                # Golang format for CLI date input
 ```
 
-Currently, `file.cusorLine` will only be applied for the following editors:
-* vi/vim
-* emacs
-* neovim
-* nano
-
-All other editors will work but will not respect this congifuration parameter.
-
 ### Environment Variable Overrides
 Any configuration parameter can be overridden by setting a corresponding environment variable.
 Note that setting an environment variable does not change the value specified in the configuration file.
@@ -357,6 +349,15 @@ The full list of environment variables is listed below and is always available b
   TEXTNOTE_CLI_TIME_FORMAT string
     	formatting string for timestamp CLI flags
 ```
+
+### Editor-Specific Configuration
+Currently, textnote supports the `file.cusorLine` and `TEXTNOTE_FILE_CURSOR_LINE` configuration for the following editors:
+* vi/vim
+* emacs
+* neovim
+* nano
+
+textnote will work with all other editors but will not respect this congifuration parameter.
 
 ## License
 textnote is released under the [MIT License](https://github.com/dkaslovsky/textnote/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Key features:
 All note files are stored locally on the file system in a single directory.
 Notes can easily be synced to a remote server or cloud service if so desired by ensuring the application directory is remotely synced.
 
-Currently, Vim is the only supported text editor.
+textnote opens notes using the text editor specified by the environment variable `$EDITOR` and defaults to Vim if the environment variable is not set.
+See [Configuration](#configuration) for more details. 
 
 ## Quick Start
 1. Install textnote (see [Installation](#installation))
@@ -301,6 +302,14 @@ archive:
 cli:
   timeFormat: "2006-01-02"                # Golang format for CLI date input
 ```
+
+Currently, `file.cusorLine` will only be applied for the following editors:
+* vi/vim
+* emacs
+* neovim
+* nano
+
+All other editors will work but will not respect this congifuration parameter.
 
 ### Environment Variable Overrides
 Any configuration parameter can be overridden by setting a corresponding environment variable.

--- a/cmd/archive/archive.go
+++ b/cmd/archive/archive.go
@@ -24,9 +24,10 @@ type commandOptions struct {
 func CreateArchiveCmd() *cobra.Command {
 	cmdOpts := commandOptions{}
 	cmd := &cobra.Command{
-		Use:   "archive",
-		Short: "consolidate notes into archive files",
-		Long:  "consolidate notes into monthly archive files",
+		Use:          "archive",
+		Short:        "consolidate notes into archive files",
+		Long:         "consolidate notes into monthly archive files",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts, err := config.LoadOrCreate()
 			if err != nil {

--- a/cmd/open/open.go
+++ b/cmd/open/open.go
@@ -180,11 +180,11 @@ func deleteSections(t *template.Template, sectionNames []string) error {
 }
 
 func openInEditor(t *template.Template, ed *editor.Editor) error {
-	if !ed.Supported {
-		log.Printf("Unsupported editor [%s] will be used with default arguments", ed.Cmd)
+	if t.GetFileCursorLine() > 0 && !ed.Supported {
+		log.Printf("Editor [%s] only supported with its default arguments, additional configuration ignored", ed.Cmd)
 	}
 	if ed.Default {
-		log.Printf("Environment variable [%s] not set, attempting to default to editor [%s]", editor.EnvEditor, ed.Cmd)
+		log.Printf("Environment variable [%s] not set, attempting to use default editor [%s]", editor.EnvEditor, ed.Cmd)
 	}
 	return file.Open(t, ed)
 }

--- a/pkg/editor/editor.go
+++ b/pkg/editor/editor.go
@@ -1,0 +1,104 @@
+package editor
+
+import "fmt"
+
+// EnvEditor is the name of the environment variable specifying the editor for opening notes
+const EnvEditor = "EDITOR"
+
+const (
+	editorNameEmacs  = "emacs"
+	editorNameNano   = "nano"
+	editorNameNeovim = "nvim"
+	editorNameVi     = "vi"
+	editorNameVim    = "vim"
+)
+
+// Editor encapsulates the commands and args necessary to open an editor in a shell
+type Editor struct {
+	Cmd       string
+	GetArgs   func(int) []string
+	Supported bool
+	Default   bool
+}
+
+// GetCmd returns the editor's command
+func (e *Editor) GetCmd() string {
+	return e.Cmd
+}
+
+// GetArgsFunc returns the editor's GetArgs function
+func (e *Editor) GetArgsFunc() func(int) []string {
+	return e.GetArgs
+}
+
+// GetEditor gets an Editor based on a provided name
+func GetEditor(name string) *Editor {
+	switch name {
+	case editorNameVi, editorNameVim:
+		return &Editor{
+			Cmd: name,
+			GetArgs: func(line int) []string {
+				return []string{
+					fmt.Sprintf("+%d", line),
+				}
+			},
+			Supported: true,
+			Default:   false,
+		}
+	case editorNameEmacs:
+		return &Editor{
+			Cmd: editorNameEmacs,
+			GetArgs: func(line int) []string {
+				return []string{
+					fmt.Sprintf("+%d", line),
+				}
+			},
+			Supported: true,
+			Default:   false,
+		}
+	case editorNameNano:
+		return &Editor{
+			Cmd: editorNameNano,
+			GetArgs: func(line int) []string {
+				return []string{
+					fmt.Sprintf("+%d", line),
+				}
+			},
+			Supported: true,
+			Default:   false,
+		}
+	case editorNameNeovim:
+		return &Editor{
+			Cmd: editorNameNeovim,
+			GetArgs: func(line int) []string {
+				return []string{
+					fmt.Sprintf("+%d", line),
+				}
+			},
+			Supported: true,
+			Default:   false,
+		}
+	// use Vim as the default editor
+	case "":
+		return &Editor{
+			Cmd: editorNameVim,
+			GetArgs: func(line int) []string {
+				return []string{
+					fmt.Sprintf("+%d", line),
+				}
+			},
+			Supported: true,
+			Default:   true,
+		}
+	// unrecognized editor will be passed no arguments
+	default:
+		return &Editor{
+			Cmd: name,
+			GetArgs: func(line int) []string {
+				return []string{}
+			},
+			Supported: false,
+			Default:   false,
+		}
+	}
+}

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -60,12 +59,19 @@ type Openable interface {
 	GetFileCursorLine() int
 }
 
-// OpenInVim opens a template in Vim
-// Recommended to use Go >= v.1.15.7 due to call to exec.Command()
+// Editor is the interface for which an editor is opened
+type Editor interface {
+	GetCmd() string
+	GetArgsFunc() func(int) []string
+}
+
+// Open opens a template in an editor
+// NOTE: it is recommended to use Go >= v.1.15.7 due to call to exec.Command()
 // See: https://blog.golang.org/path-security
-func OpenInVim(o Openable) error {
-	lineArg := fmt.Sprintf("+%d", o.GetFileCursorLine())
-	cmd := exec.Command("vim", lineArg, o.GetFilePath())
+func Open(o Openable, ed Editor) error {
+	edArgs := append(ed.GetArgsFunc()(o.GetFileCursorLine()), o.GetFilePath())
+
+	cmd := exec.Command(ed.GetCmd(), edArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
* Use $EDITOR environment variable for opening notes
* Add support for vi/vim, nano, neovim, and emacs for using `file.cursorLine` config parameter