### PR TITLE
Use defaults for unspecified params in config file

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -93,6 +93,40 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ================================================================
 
+github.com/imdario/mergo
+https://github.com/imdario/mergo
+----------------------------------------------------------------
+Copyright (c) 2013 Dario Castañé. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================
+
 github.com/inconshreveable/mousetrap
 https://github.com/inconshreveable/mousetrap
 ----------------------------------------------------------------

--- a/cmd/archive/archive.go
+++ b/cmd/archive/archive.go
@@ -50,7 +50,7 @@ func attachOpts(cmd *cobra.Command, cmdOpts *commandOptions) {
 func run(templateOpts config.Opts, cmdOpts commandOptions) error {
 	archiver := archive.NewArchiver(templateOpts, file.NewReadWriter(), time.Now())
 
-	files, err := ioutil.ReadDir(config.AppDir)
+	files, err := ioutil.ReadDir(templateOpts.AppDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/archive/archive.go
+++ b/cmd/archive/archive.go
@@ -29,7 +29,7 @@ func CreateArchiveCmd() *cobra.Command {
 		Long:         "consolidate notes into monthly archive files",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts, err := config.LoadOrCreate()
+			opts, err := config.Load()
 			if err != nil {
 				return err
 			}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -23,11 +23,6 @@ func CreateConfigCmd() *cobra.Command {
 		Short: "show configuration",
 		Long:  "displays the application's configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := config.LoadOrCreate()
-			if err != nil {
-				return err
-			}
-
 			configPath := filepath.Join(config.AppDir, config.FileName)
 
 			if cmdOpts.path {
@@ -35,7 +30,7 @@ func CreateConfigCmd() *cobra.Command {
 				return nil
 			}
 
-			_, err = os.Stat(configPath)
+			_, err := os.Stat(configPath)
 			if os.IsNotExist(err) {
 				return fmt.Errorf("cannot find configuration file [%s]", configPath)
 			}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/dkaslovsky/textnote/pkg/config"
 	"github.com/pkg/errors"
@@ -23,7 +22,7 @@ func CreateConfigCmd() *cobra.Command {
 		Short: "show configuration",
 		Long:  "displays the application's configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			configPath := filepath.Join(config.AppDir, config.FileName)
+			configPath := config.GetConfigFilePath()
 
 			if cmdOpts.path {
 				fmt.Printf("configuration file path: [%s]\n", configPath)

--- a/cmd/open/open.go
+++ b/cmd/open/open.go
@@ -35,11 +35,11 @@ func CreateOpenCmd() *cobra.Command {
 		Long:         "open or create a note template",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			now := time.Now()
-			opts, err := config.LoadOrCreate()
+			opts, err := config.Load()
 			if err != nil {
 				return err
 			}
+			now := time.Now()
 			setDateOpt(&cmdOpts, now, opts)
 			setCopyDateOpt(&cmdOpts, now, opts)
 			return run(opts, cmdOpts)
@@ -88,7 +88,7 @@ func setCopyDateOpt(cmdOpts *commandOptions, now time.Time, templateOpts config.
 		return
 	}
 	if cmdOpts.copyDaysBack != 0 {
-		// use copyDaysBack if specifed
+		// use copyDaysBack if specified
 		cmdOpts.copyDate = now.Add(-day * time.Duration(cmdOpts.copyDaysBack)).Format(templateOpts.Cli.TimeFormat)
 		return
 	}
@@ -102,10 +102,9 @@ func run(templateOpts config.Opts, cmdOpts commandOptions) error {
 		return errors.Wrapf(err, "cannot create note for malformed date [%s]", cmdOpts.date)
 	}
 
-	ed := editor.GetEditor(os.Getenv(editor.EnvEditor))
-
 	t := template.NewTemplate(templateOpts, date)
 	rw := file.NewReadWriter()
+	ed := editor.GetEditor(os.Getenv(editor.EnvEditor))
 
 	// open file if no sections to copy
 	if len(cmdOpts.sections) == 0 {

--- a/cmd/open/open.go
+++ b/cmd/open/open.go
@@ -185,5 +185,5 @@ func openInEditor(t *template.Template, ed *editor.Editor) error {
 	if ed.Default {
 		log.Printf("Environment variable [%s] not set, attempting to use default editor [%s]", editor.EnvEditor, ed.Cmd)
 	}
-	return file.Open(t, ed)
+	return ed.Open(t)
 }

--- a/cmd/open/open.go
+++ b/cmd/open/open.go
@@ -179,7 +179,7 @@ func deleteSections(t *template.Template, sectionNames []string) error {
 }
 
 func openInEditor(t *template.Template, ed *editor.Editor) error {
-	if t.GetFileCursorLine() > 0 && !ed.Supported {
+	if t.GetFileCursorLine() > 1 && !ed.Supported {
 		log.Printf("Editor [%s] only supported with its default arguments, additional configuration ignored", ed.Cmd)
 	}
 	if ed.Default {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/ilyakaznacheev/cleanenv v1.2.5
+	github.com/imdario/mergo v0.3.11
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/ilyakaznacheev/cleanenv v1.2.5 h1:/SlcF9GaIvefWqFJzsccGG/NJdoaAwb7Mm7ImzhO3DM=
 github.com/ilyakaznacheev/cleanenv v1.2.5/go.mod h1:/i3yhzwZ3s7hacNERGFwvlhwXMDcaqwIzmayEhbRplk=
+github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
+github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
@@ -294,6 +296,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/main.go
+++ b/main.go
@@ -17,6 +17,11 @@ func main() {
 		log.Fatal(err)
 	}
 
+	err = config.CreateIfNotExists()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	err = cmd.Run(name, version)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dkaslovsky/textnote/pkg/config"
 	"github.com/dkaslovsky/textnote/pkg/file"
 	"github.com/dkaslovsky/textnote/pkg/template"
 	"github.com/dkaslovsky/textnote/pkg/template/templatetest"
@@ -413,7 +412,7 @@ _p_TestSection3_q_
 
 			expectedFilesWithFullPath := []string{}
 			for _, f := range test.expectedFiles {
-				fullPath := filepath.Join(config.AppDir, f)
+				fullPath := filepath.Join(opts.AppDir, f)
 				expectedFilesWithFullPath = append(expectedFilesWithFullPath, fullPath)
 			}
 			require.ElementsMatch(t, expectedFilesWithFullPath, a.GetArchivedFiles())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,18 +144,21 @@ func Load() (Opts, error) {
 // CreateIfNotExists writes defaults to the configuration file if it does not already exist
 func CreateIfNotExists() error {
 	_, err := os.Stat(configPath)
-	if os.IsNotExist(err) {
-		defaults := getDefaultOpts()
-		yml, err := yaml.Marshal(defaults)
-		if err != nil {
-			return errors.Wrap(err, "unable to generate config file")
-		}
-		err = ioutil.WriteFile(configPath, yml, 0644)
-		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("unable to create configuration file: [%s]", configPath))
-		}
-		log.Printf("created default configuration file: [%s]", configPath)
+	if !os.IsNotExist(err) {
+		// config file exists, nothing to do
+		return nil
 	}
+
+	defaults := getDefaultOpts()
+	yml, err := yaml.Marshal(defaults)
+	if err != nil {
+		return errors.Wrap(err, "unable to generate config file")
+	}
+	err = ioutil.WriteFile(configPath, yml, 0644)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("unable to create configuration file: [%s]", configPath))
+	}
+	log.Printf("created default configuration file: [%s]", configPath)
 	return nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,15 +7,22 @@ import (
 )
 
 func TestValidateOpts(t *testing.T) {
+	t.Run("no appDir", func(t *testing.T) {
+		opts := getTestOpts()
+		opts.AppDir = ""
+		err := ValidateOpts(opts)
+		require.Error(t, err)
+	})
+
 	t.Run("no section names", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.Section.Names = []string{}
 		err := ValidateOpts(opts)
 		require.Error(t, err)
 	})
 
 	t.Run("section names are not unique", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.Section.Names = []string{
 			"section1",
 			"section2",
@@ -26,7 +33,7 @@ func TestValidateOpts(t *testing.T) {
 	})
 
 	t.Run("section names are unique", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.Section.Names = []string{
 			"section1",
 			"section2",
@@ -37,79 +44,85 @@ func TestValidateOpts(t *testing.T) {
 	})
 
 	t.Run("archive file prefix is empty string", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.Archive.FilePrefix = ""
 		err := ValidateOpts(opts)
 		require.Error(t, err)
 	})
 
 	t.Run("archive file prefix is blank", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.Archive.FilePrefix = "     "
 		err := ValidateOpts(opts)
 		require.Error(t, err)
 	})
 
 	t.Run("archive file prefix is not empty or blank", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.Archive.FilePrefix = "xyzarchivexyz"
 		err := ValidateOpts(opts)
 		require.NoError(t, err)
 	})
 
 	t.Run("archive after days is negative", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.Archive.AfterDays = -1
 		err := ValidateOpts(opts)
 		require.Error(t, err)
 	})
 
 	t.Run("archive after days is zero", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.Archive.AfterDays = 0
 		err := ValidateOpts(opts)
 		require.Error(t, err)
 	})
 
 	t.Run("archive after days is one", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.Archive.AfterDays = 1
 		err := ValidateOpts(opts)
 		require.NoError(t, err)
 	})
 
 	t.Run("empty file extension should not error", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.File.Ext = ""
 		err := ValidateOpts(opts)
 		require.NoError(t, err)
 	})
 
 	t.Run("file extension without dot should not error", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.File.Ext = "txt"
 		err := ValidateOpts(opts)
 		require.NoError(t, err)
 	})
 
 	t.Run("file extension with leading dot should not error", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.File.Ext = ".txt"
 		err := ValidateOpts(opts)
 		require.Error(t, err)
 	})
 
 	t.Run("file cursor line is negative", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.File.CursorLine = -2
 		err := ValidateOpts(opts)
 		require.Error(t, err)
 	})
 
 	t.Run("file cursor line is zero", func(t *testing.T) {
-		opts := getDefaultOpts()
+		opts := getTestOpts()
 		opts.File.CursorLine = 0
 		err := ValidateOpts(opts)
 		require.NoError(t, err)
 	})
+}
+
+func getTestOpts() Opts {
+	opts := getDefaultOpts()
+	opts.AppDir = "path/to/appDir"
+	return opts
 }

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -3,7 +3,6 @@ package file
 import (
 	"io"
 	"os"
-	"os/exec"
 )
 
 // ReadWriteable is the interface on which file operations are executed
@@ -51,29 +50,4 @@ func (rw *ReadWriter) Exists(rwable ReadWriteable) bool {
 	fileName := rwable.GetFilePath()
 	_, err := os.Stat(fileName)
 	return !os.IsNotExist(err)
-}
-
-// Openable is the interface for which a file is opened
-type Openable interface {
-	GetFilePath() string
-	GetFileCursorLine() int
-}
-
-// Editor is the interface for which an editor is opened
-type Editor interface {
-	GetCmd() string
-	GetArgsFunc() func(int) []string
-}
-
-// Open opens a template in an editor
-// NOTE: it is recommended to use Go >= v.1.15.7 due to call to exec.Command()
-// See: https://blog.golang.org/path-security
-func Open(o Openable, ed Editor) error {
-	edArgs := append(ed.GetArgsFunc()(o.GetFileCursorLine()), o.GetFilePath())
-
-	cmd := exec.Command(ed.GetCmd(), edArgs...)
-	cmd.Stdout = os.Stdout
-	cmd.Stdin = os.Stdin
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
 }

--- a/pkg/template/archive.go
+++ b/pkg/template/archive.go
@@ -35,7 +35,7 @@ func (t *MonthArchiveTemplate) Write(w io.Writer) error {
 // GetFilePath generates a full path for a file based on the template date
 func (t *MonthArchiveTemplate) GetFilePath() string {
 	name := filepath.Join(
-		config.AppDir,
+		t.opts.AppDir,
 		t.opts.Archive.FilePrefix+t.date.Format(t.opts.Archive.MonthTimeFormat),
 	)
 	if t.opts.File.Ext == "" {

--- a/pkg/template/archive_test.go
+++ b/pkg/template/archive_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dkaslovsky/textnote/pkg/config"
 	"github.com/dkaslovsky/textnote/pkg/template/templatetest"
 	"github.com/stretchr/testify/require"
 )
@@ -46,11 +45,11 @@ func TestArchiveGetFilePath(t *testing.T) {
 		opts.File.Ext = "txt"
 		template := NewMonthArchiveTemplate(opts, templatetest.Date)
 		filePath := template.GetFilePath()
-		require.True(t, strings.HasPrefix(filePath, config.AppDir))
+		require.True(t, strings.HasPrefix(filePath, opts.AppDir))
 		require.True(t, strings.HasSuffix(filePath, ".txt"))
 		require.Equal(t,
 			opts.Archive.FilePrefix+templatetest.Date.Format(opts.Archive.MonthTimeFormat),
-			stripPrefixSuffix(filePath, fmt.Sprintf("%s/", config.AppDir), ".txt"),
+			stripPrefixSuffix(filePath, fmt.Sprintf("%s/", opts.AppDir), ".txt"),
 		)
 	})
 
@@ -59,11 +58,11 @@ func TestArchiveGetFilePath(t *testing.T) {
 		opts.File.Ext = ""
 		template := NewMonthArchiveTemplate(opts, templatetest.Date)
 		filePath := template.GetFilePath()
-		require.True(t, strings.HasPrefix(filePath, config.AppDir))
+		require.True(t, strings.HasPrefix(filePath, opts.AppDir))
 		require.False(t, strings.HasSuffix(filePath, "."))
 		require.Equal(t,
 			opts.Archive.FilePrefix+templatetest.Date.Format(opts.Archive.MonthTimeFormat),
-			stripPrefixSuffix(filePath, fmt.Sprintf("%s/", config.AppDir), ""),
+			stripPrefixSuffix(filePath, fmt.Sprintf("%s/", opts.AppDir), ""),
 		)
 	})
 }
@@ -88,7 +87,7 @@ func TestArchiveSectionContents(t *testing.T) {
 		"archive empty contents into populated section": {
 			sectionName: "TestSection1",
 			existingContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date, templatetest.GetOpts()),
 					text:   "existingText1",
 				},
@@ -96,7 +95,7 @@ func TestArchiveSectionContents(t *testing.T) {
 			sourceDate:     templatetest.Date.Add(24 * time.Hour),
 			sourceContents: []contentItem{},
 			expectedContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date, templatetest.GetOpts()),
 					text:   "existingText1",
 				},
@@ -107,13 +106,13 @@ func TestArchiveSectionContents(t *testing.T) {
 			existingContents: []contentItem{},
 			sourceDate:       templatetest.Date.Add(24 * time.Hour),
 			sourceContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(24*time.Hour), templatetest.GetOpts()),
 					text:   "text1",
 				},
 			},
 			expectedContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(24*time.Hour), templatetest.GetOpts()),
 					text:   "text1",
 				},
@@ -122,24 +121,24 @@ func TestArchiveSectionContents(t *testing.T) {
 		"archive contents with single element into populated section": {
 			sectionName: "TestSection1",
 			existingContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date, templatetest.GetOpts()),
 					text:   "existingText1",
 				},
 			},
 			sourceDate: templatetest.Date.Add(24 * time.Hour),
 			sourceContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(24*time.Hour), templatetest.GetOpts()),
 					text:   "sourceText1",
 				},
 			},
 			expectedContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date, templatetest.GetOpts()),
 					text:   "existingText1",
 				},
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(24*time.Hour), templatetest.GetOpts()),
 					text:   "sourceText1",
 				},
@@ -150,17 +149,17 @@ func TestArchiveSectionContents(t *testing.T) {
 			existingContents: []contentItem{},
 			sourceDate:       templatetest.Date.Add(24 * time.Hour),
 			sourceContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(24*time.Hour), templatetest.GetOpts()),
 					text:   "text1\n",
 				},
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(24*time.Hour), templatetest.GetOpts()),
 					text:   "text2\n\n",
 				},
 			},
 			expectedContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(24*time.Hour), templatetest.GetOpts()),
 					text:   "text1\ntext2\n\n",
 				},
@@ -169,28 +168,28 @@ func TestArchiveSectionContents(t *testing.T) {
 		"archive contents with multiple elements into populated section": {
 			sectionName: "TestSection1",
 			existingContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(-24*time.Hour), templatetest.GetOpts()),
 					text:   "existingText",
 				},
 			},
 			sourceDate: templatetest.Date.Add(24 * time.Hour),
 			sourceContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(24*time.Hour), templatetest.GetOpts()),
 					text:   "text1\n",
 				},
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(24*time.Hour), templatetest.GetOpts()),
 					text:   "text2\n\n",
 				},
 			},
 			expectedContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(-24*time.Hour), templatetest.GetOpts()),
 					text:   "existingText",
 				},
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(24*time.Hour), templatetest.GetOpts()),
 					text:   "text1\ntext2\n\n",
 				},
@@ -199,28 +198,28 @@ func TestArchiveSectionContents(t *testing.T) {
 		"archive contents from source with same date": {
 			sectionName: "TestSection1",
 			existingContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date, templatetest.GetOpts()),
 					text:   "existingText",
 				},
 			},
 			sourceDate: templatetest.Date,
 			sourceContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date, templatetest.GetOpts()),
 					text:   "text1\n",
 				},
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date, templatetest.GetOpts()),
 					text:   "text2\n\n",
 				},
 			},
 			expectedContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date, templatetest.GetOpts()),
 					text:   "existingText",
 				},
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date, templatetest.GetOpts()),
 					text:   "text1\ntext2\n\n",
 				},
@@ -231,17 +230,17 @@ func TestArchiveSectionContents(t *testing.T) {
 			existingContents: []contentItem{},
 			sourceDate:       templatetest.Date.Add(24 * time.Hour),
 			sourceContents: []contentItem{
-				contentItem{
+				{
 					header: "doesn't matter 1",
 					text:   "text1\n",
 				},
-				contentItem{
+				{
 					header: "doesn't matter 2",
 					text:   "text2\n\n",
 				},
 			},
 			expectedContents: []contentItem{
-				contentItem{
+				{
 					header: templatetest.MakeItemHeader(templatetest.Date.Add(24*time.Hour), templatetest.GetOpts()),
 					text:   "text1\ntext2\n\n",
 				},

--- a/pkg/template/section_test.go
+++ b/pkg/template/section_test.go
@@ -79,7 +79,7 @@ func TestGetContentString(t *testing.T) {
 		},
 		"single empty string contents with no header": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "",
 					text:   "",
 				},
@@ -88,7 +88,7 @@ func TestGetContentString(t *testing.T) {
 		},
 		"single empty string contents with header": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "header",
 					text:   "",
 				},
@@ -97,11 +97,11 @@ func TestGetContentString(t *testing.T) {
 		},
 		"multiple empty string contents with no header": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "",
 					text:   "",
 				},
-				contentItem{
+				{
 					header: "",
 					text:   "",
 				},
@@ -110,11 +110,11 @@ func TestGetContentString(t *testing.T) {
 		},
 		"multiple empty string contents with header": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "header1",
 					text:   "",
 				},
-				contentItem{
+				{
 					header: "header2",
 					text:   "",
 				},
@@ -123,7 +123,7 @@ func TestGetContentString(t *testing.T) {
 		},
 		"single nonempty contents with no header missing trailing newline": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "",
 					text:   "text\n goes\n  here",
 				},
@@ -132,7 +132,7 @@ func TestGetContentString(t *testing.T) {
 		},
 		"single nonempty contents with no header": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "",
 					text:   "text\n goes\n  here\n",
 				},
@@ -141,7 +141,7 @@ func TestGetContentString(t *testing.T) {
 		},
 		"single nonempty contents with header": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "header",
 					text:   "text\n goes\n  here\n",
 				},
@@ -150,11 +150,11 @@ func TestGetContentString(t *testing.T) {
 		},
 		"multiple nonempty contents with no headers": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "",
 					text:   "text\n goes\n  here\n",
 				},
-				contentItem{
+				{
 					header: "",
 					text:   "text2\n goes2\n  here2 \n",
 				},
@@ -163,11 +163,11 @@ func TestGetContentString(t *testing.T) {
 		},
 		"multiple nonempty contents with headers": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "header1 ",
 					text:   "text\n goes\n  here\n",
 				},
-				contentItem{
+				{
 					header: " header2",
 					text:   "text2\n goes2\n  here2 \n",
 				},
@@ -339,7 +339,7 @@ func TestIsEmptyContents(t *testing.T) {
 		},
 		"single content with only newlines and empty header": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "",
 					text:   "\n\n\n",
 				},
@@ -348,7 +348,7 @@ func TestIsEmptyContents(t *testing.T) {
 		},
 		"single content with only newlines and populated header": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "header",
 					text:   "\n\n\n",
 				},
@@ -357,11 +357,11 @@ func TestIsEmptyContents(t *testing.T) {
 		},
 		"multiple contents with only newlines and empty headers": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "",
 					text:   "\n\n\n",
 				},
-				contentItem{
+				{
 					header: "",
 					text:   "\n",
 				},
@@ -370,11 +370,11 @@ func TestIsEmptyContents(t *testing.T) {
 		},
 		"multiple contents with only newlines and populated headers": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "header1",
 					text:   "\n\n\n",
 				},
-				contentItem{
+				{
 					header: "header2",
 					text:   "\n",
 				},
@@ -383,7 +383,7 @@ func TestIsEmptyContents(t *testing.T) {
 		},
 		"single content with text and no header": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "",
 					text:   "\n\nfoo\n",
 				},
@@ -392,7 +392,7 @@ func TestIsEmptyContents(t *testing.T) {
 		},
 		"single content with text and populated header": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "header",
 					text:   "\n\nfoo\n",
 				},
@@ -401,11 +401,11 @@ func TestIsEmptyContents(t *testing.T) {
 		},
 		"multiple contents with text and no headers": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "",
 					text:   "\n\nfoo\n",
 				},
-				contentItem{
+				{
 					header: "",
 					text:   "bar",
 				},
@@ -414,11 +414,11 @@ func TestIsEmptyContents(t *testing.T) {
 		},
 		"multiple contents with text and populated headers": {
 			contents: []contentItem{
-				contentItem{
+				{
 					header: "header1",
 					text:   "\n\nfoo\n",
 				},
-				contentItem{
+				{
 					header: "header2",
 					text:   "bar",
 				},

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -53,7 +53,7 @@ func (t *Template) GetFileCursorLine() int {
 
 // GetFilePath generates a full path for a file based on the template date
 func (t *Template) GetFilePath() string {
-	name := filepath.Join(config.AppDir, t.date.Format(t.opts.File.TimeFormat))
+	name := filepath.Join(t.opts.AppDir, t.date.Format(t.opts.File.TimeFormat))
 	if t.opts.File.Ext == "" {
 		return name
 	}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -73,10 +73,10 @@ func TestGetFilePath(t *testing.T) {
 		opts.File.Ext = "txt"
 		template := NewTemplate(opts, templatetest.Date)
 		filePath := template.GetFilePath()
-		require.True(t, strings.HasPrefix(filePath, config.AppDir))
+		require.True(t, strings.HasPrefix(filePath, opts.AppDir))
 		require.True(t, strings.HasSuffix(filePath, ".txt"))
 		require.Equal(t, templatetest.Date.Format(opts.File.TimeFormat), stripPrefixSuffix(filePath,
-			fmt.Sprintf("%s/", config.AppDir), ".txt"),
+			fmt.Sprintf("%s/", opts.AppDir), ".txt"),
 		)
 	})
 
@@ -85,10 +85,10 @@ func TestGetFilePath(t *testing.T) {
 		opts.File.Ext = ""
 		template := NewTemplate(opts, templatetest.Date)
 		filePath := template.GetFilePath()
-		require.True(t, strings.HasPrefix(filePath, config.AppDir))
+		require.True(t, strings.HasPrefix(filePath, opts.AppDir))
 		require.False(t, strings.HasSuffix(filePath, "."))
 		require.Equal(t, templatetest.Date.Format(opts.File.TimeFormat), stripPrefixSuffix(filePath,
-			fmt.Sprintf("%s/", config.AppDir), ""),
+			fmt.Sprintf("%s/", opts.AppDir), ""),
 		)
 	})
 }
@@ -109,7 +109,7 @@ func TestCopySectionContents(t *testing.T) {
 		"copy empty contents into populated section": {
 			sectionName: "TestSection1",
 			existingContents: []contentItem{
-				contentItem{
+				{
 					header: "existingHeader",
 					text:   "existingText1",
 				},
@@ -120,7 +120,7 @@ func TestCopySectionContents(t *testing.T) {
 			sectionName:      "TestSection1",
 			existingContents: []contentItem{},
 			incomingContents: []contentItem{
-				contentItem{
+				{
 					header: "header",
 					text:   "text1",
 				},
@@ -129,13 +129,13 @@ func TestCopySectionContents(t *testing.T) {
 		"copy contents with single element into populated section": {
 			sectionName: "TestSection1",
 			existingContents: []contentItem{
-				contentItem{
+				{
 					header: "existingHeader",
 					text:   "existingText1",
 				},
 			},
 			incomingContents: []contentItem{
-				contentItem{
+				{
 					header: "header",
 					text:   "text1",
 				},
@@ -145,11 +145,11 @@ func TestCopySectionContents(t *testing.T) {
 			sectionName:      "TestSection1",
 			existingContents: []contentItem{},
 			incomingContents: []contentItem{
-				contentItem{
+				{
 					header: "header1",
 					text:   "text1",
 				},
-				contentItem{
+				{
 					header: "header2",
 					text:   "text2",
 				},
@@ -158,17 +158,17 @@ func TestCopySectionContents(t *testing.T) {
 		"copy contents with multiple elements into populated section": {
 			sectionName: "TestSection1",
 			existingContents: []contentItem{
-				contentItem{
+				{
 					header: "existingHeader",
 					text:   "existingText1",
 				},
 			},
 			incomingContents: []contentItem{
-				contentItem{
+				{
 					header: "header1",
 					text:   "text1",
 				},
-				contentItem{
+				{
 					header: "header2",
 					text:   "text2",
 				},

--- a/pkg/template/templatetest/templatetest.go
+++ b/pkg/template/templatetest/templatetest.go
@@ -15,6 +15,7 @@ var Date = time.Date(2020, 12, 20, 1, 1, 1, 1, time.UTC)
 // GetOpts returns a configuration struct for tests - changing these values will affect some tests
 func GetOpts() config.Opts {
 	opts := config.Opts{
+		AppDir: "path/to/app/dir",
 		Header: config.HeaderOpts{
 			Prefix:           "-^-",
 			Suffix:           "-v-",


### PR DESCRIPTION
- Use defaults for unspecified params in config file so that fields are not required in config file. This will also allow for additive changes to the configuration in the future
- Display warning on cursor line > 2 for unsupported editors
- Remove use appdir global variable