### PR TITLE
Use latest existing note for opening and copying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
   - 1.13.x
   - 1.14.x
   - 1.15.x
+  - 1.16.x
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ env:
   - GO111MODULE=on TEXTNOTE_DIR=/tmp
 
 go:
-  - 1.13.x
-  - 1.14.x
-  - 1.15.x
   - 1.16.x
 
 branches:

--- a/README.md
+++ b/README.md
@@ -284,6 +284,39 @@ The `config` command with the `-a` flag displays the full "active" configuration
 ```
 $ textnote config -a
 ```
+To update the configuration file to match the active configuration, run
+```
+$ textnote config update
+```
+This command overwrites the existing configuration file.
+It can be used instead of manual updates to the configuration file by passing environment variables.
+For example,
+```
+$ TEXTNOTE_ARCHIVE_FILE_PREFIX="my_archive-" textnote config update
+```
+The `update` command is also helpful for writing configuration parameters that have been added with new versions of textnote.
+
+The `config` command options are summarized by the command's help:
+```
+$ textnote config -h
+
+manages the application's configuration
+
+Usage:
+  textnote config [flags]
+  textnote config [command]
+
+Available Commands:
+  update      update the configuration file with active configuration
+
+Flags:
+  -a, --active   display configuration the application actively uses (includes environment variable configuration)
+  -f, --file     display contents of configuration file (default)
+  -h, --help     help for config
+  -p, --path     display path to configuration file
+
+Use "textnote config [command] --help" for more information about a command.
+```
 
 ### Defaults
 The default configuration file is automatically written the first time textnote is run:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ textnote
 
 To first configure textnote before creating notes, run
 ```
-$ textnote config -p
+$ textnote init
 ```
 and then edit the configuration file found at the displayed path.
 
@@ -116,12 +116,12 @@ opens yesterday's note.
 
 Sections from previous notes can be copied or moved into a current note.
 Each section to be copied is specified in a separate `-s` flag.
-The previous day's note is used as the source by default and a specific date for a source note can be provided through the `--copy` flag.
+The most recent dated note is used as the source by default and a specific date for a source note can be provided through the `--copy` flag.
 For example,
 ```
 $ textnote open -s TODO -s NOTES
 ```
-will create today's note with the "TODO" and "NOTES" sections copied from yesterday's note, while
+will create today's note with the "TODO" and "NOTES" sections copied from the most recently dated (often yesterday's) note, while
 ```
 $ textnote open --copy 2021-01-17 -s TODO
 ```
@@ -146,12 +146,21 @@ For convenience, the `-t` flag can be used to open tomorrow's note:
 ```
 $ textnote open -t
 ```
-in which case the copy source defaults to today.
 For example,
 ```
 $ textnote open -t -s TODO
 ```
-creates a note for tomorrow with a copy of today's "TODO" section contents.
+creates a note for tomorrow with a copy of today's "TODO" section contents, assuming a note for today exits.
+Also for convenience, the latest dated note can be opened using the `-l` flag, noting that notes dated in the future are ignored.
+For example,
+```
+$ textnote open -l
+```
+opens today's note if it exists or the most recently dated note otherwise.
+
+When opening or copying from a note requires searching for the latest (most recently dated) note, textnote checks the number of template files that were required to be searched.
+If this number is above a threshold (as set in the [configuration](#configuration)), a message suggesting to run the [archive](#archive) command to reduce the number of template files is displayed.
+This message can be effectively disabled by configuring the `templateFileCountThresh` configuration parameter to be very large, but doing so is not recommended.
 
 The flag options are summarized by the command's help:
 ```
@@ -163,14 +172,15 @@ Usage:
   textnote open [flags]
 
 Flags:
-      --copy string       date of note for copying sections (defaults to yesterday)
-  -c, --copy-back uint    number of days back from today for copying from a note (ignored if copy flag is used)
+      --copy string       date of note for copying sections (defaults to date of most recent note, cannot be used with copy-back flag)
+  -c, --copy-back uint    number of days back from today for copying from a note (cannot be used with copy flag)
       --date string       date for note to be opened (defaults to today)
-  -d, --days-back uint    number of days back from today for opening a note (ignored if date or tomorrow flags are used)
+  -d, --days-back uint    number of days back from today for opening a note (cannot be used with date, tomorrow, or latest flags)
   -x, --delete            delete sections after copy
   -h, --help              help for open
+  -l, --latest            specify the most recent dated note to be opened (cannot be used with date, days-back, or tomorrow flags)
   -s, --section strings   section to copy (defaults to none)
-  -t, --tomorrow          specify tomorrow as the date for note to be opened (ignored if date flag is used)
+  -t, --tomorrow          specify tomorrow as the date for note to be opened (cannot be used with date, days-back, or latest flags)
 ```
 
 
@@ -261,13 +271,18 @@ Individual configuration parameters also can be overridden with [environment var
 
 Importantly, if textnote's configuration is changed, notes created using a previous configuration might be incompatible with textnote's functionality.
 
-The current configuration can be displayed by running the `config` command:
+The configuration file can be displayed by running the `config` command with the `-f` flag:
 ```
-$ textnote config
+$ textnote config -f
 ```
 The configuration file path is displayed by using the `-p` flag:
 ```
 $ textnote config -p
+```
+[Defaults](#defaults) are used for configuration parameters omitted from the configuration file or configuration [environment variables](#environment-variable-overrides).
+The `config` command with the `-a` flag displays the full "active" configuration used when the application runs, including default and environment parameters:
+```
+$ textnote config -a
 ```
 
 ### Defaults
@@ -301,6 +316,7 @@ archive:
   monthTimeFormat: Jan2006                # Golang format for month archive file and header dates
 cli:
   timeFormat: "2006-01-02"                # Golang format for CLI date input
+templateFileCountTresh: 90                # threshold for displaying a warning for too many template files
 ```
 
 ### Environment Variable Overrides
@@ -308,6 +324,8 @@ Any configuration parameter can be overridden by setting a corresponding environ
 Note that setting an environment variable does not change the value specified in the configuration file.
 The full list of environment variables is listed below and is always available by running `textnote --help`:
 ```
+  TEXTNOTE_TEMPLATE_FILE_COUNT_THRESH int
+    	threshold for warning too many template files
   TEXTNOTE_HEADER_PREFIX string
     	prefix to attach to header
   TEXTNOTE_HEADER_SUFFIX string

--- a/README.md
+++ b/README.md
@@ -151,15 +151,16 @@ For example,
 $ textnote open -t -s TODO
 ```
 creates a note for tomorrow with a copy of today's "TODO" section contents, assuming a note for today exits.
-Also for convenience, the latest dated note can be opened using the `-l` flag, noting that notes dated in the future are ignored.
-For example,
+
+Also for convenience, the latest (most recent) dated note can be opened using the `-l` flag:
 ```
 $ textnote open -l
 ```
-opens today's note if it exists or the most recently dated note otherwise.
+The most recently dated note is typically from the previous day or a few days ago, but this command will return the note for the current date if it already exists.
+It will ignore notes dated in the future.
 
-When opening or copying from a note requires searching for the latest (most recently dated) note, textnote checks the number of template files that were required to be searched.
-If this number is above a threshold (as set in the [configuration](#configuration)), a message suggesting to run the [archive](#archive) command to reduce the number of template files is displayed.
+When opening/copying requires searching for the latest (most recently dated) note, textnote checks the number of template files that were required to be searched.
+If this number is above a threshold (as set in the [configuration](#configuration)), a message is displayed suggesting to run the [archive](#archive) command to reduce the number of template files.
 This message can be effectively disabled by configuring the `templateFileCountThresh` configuration parameter to be very large, but doing so is not recommended.
 
 The flag options are summarized by the command's help:
@@ -403,10 +404,10 @@ The full list of environment variables is listed below and is always available b
 
 ### Editor-Specific Configuration
 Currently, textnote supports the `file.cusorLine` and `TEXTNOTE_FILE_CURSOR_LINE` configuration for the following editors:
-* vi/vim
-* emacs
-* neovim
-* nano
+* Vi/Vim
+* Emacs
+* Neovim
+* Nano
 
 textnote will work with all other editors but will not respect this congifuration parameter.
 

--- a/cmd/archive/archive.go
+++ b/cmd/archive/archive.go
@@ -2,7 +2,6 @@ package archive
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -50,7 +49,7 @@ func attachOpts(cmd *cobra.Command, cmdOpts *commandOptions) {
 func run(templateOpts config.Opts, cmdOpts commandOptions) error {
 	archiver := archive.NewArchiver(templateOpts, file.NewReadWriter(), time.Now())
 
-	files, err := ioutil.ReadDir(templateOpts.AppDir)
+	files, err := os.ReadDir(templateOpts.AppDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -38,7 +38,7 @@ func CreateConfigCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "unable to open configuration file [%s]", configPath)
 			}
-			c, err := ioutil.ReadAll(f)
+			c, err := io.ReadAll(f)
 			if err != nil {
 				return errors.Wrapf(err, "unable to read configuration file [%s]", configPath)
 			}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -9,10 +9,13 @@ import (
 	"github.com/dkaslovsky/textnote/pkg/config"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 type commandOptions struct {
-	path bool
+	path   bool
+	active bool
+	file   bool
 }
 
 // CreateConfigCmd creates the config subcommand
@@ -26,24 +29,16 @@ func CreateConfigCmd() *cobra.Command {
 			configPath := config.GetConfigFilePath()
 
 			if cmdOpts.path {
-				log.Printf("configuration file path: [%s]\n", configPath)
+				log.Printf("configuration file path: [%s]", configPath)
 				return nil
 			}
 
-			_, err := os.Stat(configPath)
-			if os.IsNotExist(err) {
-				return fmt.Errorf("cannot find configuration file [%s]", configPath)
+			if cmdOpts.active {
+				return displayActiveConfig()
 			}
-			f, err := os.Open(configPath)
-			if err != nil {
-				return errors.Wrapf(err, "unable to open configuration file [%s]", configPath)
-			}
-			c, err := io.ReadAll(f)
-			if err != nil {
-				return errors.Wrapf(err, "unable to read configuration file [%s]", configPath)
-			}
-			log.Printf("%s", c)
-			return nil
+
+			// default
+			return displayConfigFile(configPath)
 		},
 	}
 	attachOpts(cmd, &cmdOpts)
@@ -52,5 +47,39 @@ func CreateConfigCmd() *cobra.Command {
 
 func attachOpts(cmd *cobra.Command, cmdOpts *commandOptions) {
 	flags := cmd.Flags()
-	flags.BoolVarP(&cmdOpts.path, "path", "p", false, "print path to configuration file")
+	flags.BoolVarP(&cmdOpts.path, "path", "p", false, "display path to configuration file")
+	flags.BoolVarP(&cmdOpts.active, "active", "a", false, "display configuration the application actively uses (includes environment variable configuration)")
+	flags.BoolVarP(&cmdOpts.file, "file", "f", false, "display contents of configuration file (default)")
+}
+
+func displayConfigFile(configPath string) error {
+	_, err := os.Stat(configPath)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("cannot find configuration file [%s]", configPath)
+	}
+	f, err := os.Open(configPath)
+	if err != nil {
+		return errors.Wrapf(err, "unable to open configuration file [%s]", configPath)
+	}
+	c, err := io.ReadAll(f)
+	if err != nil {
+		return errors.Wrapf(err, "unable to read configuration file [%s]", configPath)
+	}
+	log.Print(string(c))
+	return nil
+}
+
+func displayActiveConfig() error {
+	opts, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	yml, err := yaml.Marshal(opts)
+	if err != nil {
+		return err
+	}
+
+	log.Print(string(yml))
+	return nil
 }

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 
 	"github.com/dkaslovsky/textnote/pkg/config"
@@ -25,7 +26,7 @@ func CreateConfigCmd() *cobra.Command {
 			configPath := config.GetConfigFilePath()
 
 			if cmdOpts.path {
-				fmt.Printf("configuration file path: [%s]\n", configPath)
+				log.Printf("configuration file path: [%s]\n", configPath)
 				return nil
 			}
 
@@ -41,7 +42,7 @@ func CreateConfigCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "unable to read configuration file [%s]", configPath)
 			}
-			fmt.Printf("%s", c)
+			log.Printf("%s", c)
 			return nil
 		},
 	}

--- a/cmd/initialize/initialize.go
+++ b/cmd/initialize/initialize.go
@@ -1,0 +1,20 @@
+package initialize
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/dkaslovsky/textnote/pkg/config"
+)
+
+// CreateInitCmd creates the init subcommand
+func CreateInitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "initialize the application",
+		Long:  "initialize the application's required directories and files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return config.InitApp()
+		},
+	}
+	return cmd
+}

--- a/cmd/open/open.go
+++ b/cmd/open/open.go
@@ -110,7 +110,7 @@ func setDateOpt(cmdOpts *commandOptions, templateOpts config.Opts, getFiles func
 		if err != nil {
 			return err
 		}
-		latest, found := getLatestFile(files, now, templateOpts.File)
+		latest, found := getLatestTemplateFile(files, now, templateOpts.File)
 		if !found {
 			return fmt.Errorf("failed to find latest template file in [%s]", templateOpts.AppDir)
 		}
@@ -147,7 +147,7 @@ func setCopyDateOpt(cmdOpts *commandOptions, templateOpts config.Opts, getFiles 
 	if err != nil {
 		return err
 	}
-	latest, found := getLatestFile(files, now, templateOpts.File)
+	latest, found := getLatestTemplateFile(files, now, templateOpts.File)
 	// set copyDate to be empty if no latest file is found and return nil error,
 	// otherwise an error will be raised on the app's first use
 	if !found {
@@ -259,7 +259,7 @@ func openInEditor(t *template.Template, ed *editor.Editor) error {
 	return ed.Open(t)
 }
 
-func getLatestFile(files []string, now time.Time, opts config.FileOpts) (string, bool) {
+func getLatestTemplateFile(files []string, now time.Time, opts config.FileOpts) (string, bool) {
 	delta := math.Inf(1)
 	latest := ""
 

--- a/cmd/open/open.go
+++ b/cmd/open/open.go
@@ -2,7 +2,6 @@ package open
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -267,6 +266,7 @@ func getLatestFile(files []string, now time.Time, opts config.FileOpts) (string,
 	for _, f := range files {
 		fileTime, ok := template.ParseTemplateFileName(f, opts)
 		if !ok {
+			// skip archive files and other non-template files that cannot be parsed
 			continue
 		}
 		curdelta := now.Sub(fileTime).Hours()
@@ -286,16 +286,16 @@ func getLatestFile(files []string, now time.Time, opts config.FileOpts) (string,
 func getDirFiles(dir string) ([]string, error) {
 	fileNames := []string{}
 
-	fInfo, err := ioutil.ReadDir(dir)
+	dirItems, err := os.ReadDir(dir)
 	if err != nil {
 		return fileNames, err
 	}
 
-	for _, f := range fInfo {
-		if f.IsDir() {
+	for _, item := range dirItems {
+		if item.IsDir() {
 			continue
 		}
-		fileNames = append(fileNames, f.Name())
+		fileNames = append(fileNames, item.Name())
 	}
 
 	return fileNames, nil

--- a/cmd/open/open.go
+++ b/cmd/open/open.go
@@ -149,8 +149,8 @@ func setCopyDateOpt(cmdOpts *commandOptions, templateOpts config.Opts, getFiles 
 		return err
 	}
 	latest, found := getLatestFile(files, now, templateOpts.File)
-	// set copyDate to be empty if no latest file is found, otherwise an error will be raised on
-	// the app's first use
+	// set copyDate to be empty if no latest file is found and return nil error,
+	// otherwise an error will be raised on the app's first use
 	if !found {
 		cmdOpts.copyDate = ""
 		return nil

--- a/cmd/open/open_test.go
+++ b/cmd/open/open_test.go
@@ -1,0 +1,265 @@
+package open
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dkaslovsky/textnote/pkg/template/templatetest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLatestFile(t *testing.T) {
+	opts := templatetest.GetOpts()
+
+	type testCase struct {
+		files     []string
+		now       time.Time
+		expected  string
+		shouldErr bool
+	}
+
+	tests := map[string]testCase{
+		"empty directory": {
+			files:     []string{},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "",
+			shouldErr: true,
+		},
+		"no timestamped template files": {
+			files: []string{
+				"archive-Dec2019.txt",
+				"archive-2019-11-01.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "",
+			shouldErr: true,
+		},
+		"single template file in future": {
+			files: []string{
+				"2020-04-13.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "",
+			shouldErr: true,
+		},
+		"single template file": {
+			files: []string{
+				"2020-03-11.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "2020-03-11.txt",
+			shouldErr: false,
+		},
+		"multiple template files": {
+			files: []string{
+				"2020-03-11.txt",
+				"2020-03-12.txt",
+				"2020-03-13.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "2020-03-13.txt",
+			shouldErr: false,
+		},
+		"multiple template files with one in future": {
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-12.txt",
+				"2020-04-13.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "2020-04-12.txt",
+			shouldErr: false,
+		},
+		"mix of timestamped template files and other files": {
+			files: []string{
+				".config",
+				"foobar",
+				"2020-03-11.txt",
+				"2020-03-12.txt",
+				"2020-03-13.txt",
+				"archive_April2020",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "2020-03-13.txt",
+			shouldErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			latest, err := getLatestFile(test.files, test.now, opts.File)
+			if test.shouldErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, latest)
+		})
+	}
+}
+
+func TestSetDateOpt(t *testing.T) {
+	templateOpts := templatetest.GetOpts()
+
+	type testCase struct {
+		cmdOpts   *commandOptions
+		files     []string
+		now       time.Time
+		expected  string
+		shouldErr bool
+	}
+
+	tests := map[string]testCase{
+		"multiple mutually exclusive flags: date and daysBack set": {
+			cmdOpts: &commandOptions{
+				date:     "2020-04-11",
+				daysBack: 2,
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "",
+			shouldErr: true,
+		},
+		"multiple mutually exclusive flags: date and tomorrow set": {
+			cmdOpts: &commandOptions{
+				date:     "2020-04-11",
+				tomorrow: true,
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "",
+			shouldErr: true,
+		},
+		"multiple mutually exclusive flags: date and latest set": {
+			cmdOpts: &commandOptions{
+				date:   "2020-04-11",
+				latest: true,
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "",
+			shouldErr: true,
+		},
+		"multiple mutually exclusive flags: daysBack and tomorrow set": {
+			cmdOpts: &commandOptions{
+				daysBack: 2,
+				tomorrow: true,
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "",
+			shouldErr: true,
+		},
+		"multiple mutually exclusive flags: daysBack and latest set": {
+			cmdOpts: &commandOptions{
+				daysBack: 2,
+				latest:   true,
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "",
+			shouldErr: true,
+		},
+		"multiple mutually exclusive flags: tomorrow and latest set": {
+			cmdOpts: &commandOptions{
+				tomorrow: true,
+				latest:   true,
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "",
+			shouldErr: true,
+		},
+		"use date": {
+			cmdOpts: &commandOptions{
+				date: "2020-04-11",
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "2020-04-11",
+			shouldErr: false,
+		},
+		"use daysBack": {
+			cmdOpts: &commandOptions{
+				daysBack: 2,
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "2020-04-10",
+			shouldErr: false,
+		},
+		"use tomorrow": {
+			cmdOpts: &commandOptions{
+				tomorrow: true,
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "2020-04-13",
+			shouldErr: false,
+		},
+		"use latest": {
+			cmdOpts: &commandOptions{
+				latest: true,
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
+			expected:  "2020-04-11",
+			shouldErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			getFiles := func(dir string) ([]string, error) {
+				return test.files, nil
+			}
+			err := setDateOpt(test.cmdOpts, templateOpts, getFiles, test.now)
+			if test.shouldErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, test.cmdOpts.date)
+		})
+	}
+}

--- a/cmd/open/open_test.go
+++ b/cmd/open/open_test.go
@@ -98,11 +98,13 @@ func TestSetDateOpt(t *testing.T) {
 	templateOpts := templatetest.GetOpts()
 
 	type testCase struct {
-		cmdOpts   *commandOptions
-		files     []string
-		now       time.Time
-		expected  string
-		shouldErr bool
+		cmdOpts    *commandOptions
+		files      []string
+		now        time.Time
+		expected   string
+		shouldErr  bool
+		shouldWarn bool
+		warnThresh int
 	}
 
 	tests := map[string]testCase{
@@ -116,8 +118,9 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			shouldErr: true,
+			now:        time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			shouldErr:  true,
+			shouldWarn: false,
 		},
 		"multiple mutually exclusive flags: date and tomorrow set": {
 			cmdOpts: &commandOptions{
@@ -129,8 +132,9 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			shouldErr: true,
+			now:        time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			shouldErr:  true,
+			shouldWarn: false,
 		},
 		"multiple mutually exclusive flags: date and latest set": {
 			cmdOpts: &commandOptions{
@@ -142,8 +146,9 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			shouldErr: true,
+			now:        time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			shouldErr:  true,
+			shouldWarn: false,
 		},
 		"multiple mutually exclusive flags: daysBack and tomorrow set": {
 			cmdOpts: &commandOptions{
@@ -155,8 +160,9 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			shouldErr: true,
+			now:        time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			shouldErr:  true,
+			shouldWarn: false,
 		},
 		"multiple mutually exclusive flags: daysBack and latest set": {
 			cmdOpts: &commandOptions{
@@ -168,8 +174,9 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			shouldErr: true,
+			now:        time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			shouldErr:  true,
+			shouldWarn: false,
 		},
 		"multiple mutually exclusive flags: tomorrow and latest set": {
 			cmdOpts: &commandOptions{
@@ -181,8 +188,9 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			shouldErr: true,
+			now:        time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			shouldErr:  true,
+			shouldWarn: false,
 		},
 		"use date": {
 			cmdOpts: &commandOptions{
@@ -193,9 +201,10 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "2020-04-11",
-			shouldErr: false,
+			now:        time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:   "2020-04-11",
+			shouldErr:  false,
+			shouldWarn: false,
 		},
 		"use daysBack": {
 			cmdOpts: &commandOptions{
@@ -206,9 +215,10 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "2020-04-10",
-			shouldErr: false,
+			now:        time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:   "2020-04-10",
+			shouldErr:  false,
+			shouldWarn: false,
 		},
 		"use tomorrow": {
 			cmdOpts: &commandOptions{
@@ -219,9 +229,10 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "2020-04-13",
-			shouldErr: false,
+			now:        time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:   "2020-04-13",
+			shouldErr:  false,
+			shouldWarn: false,
 		},
 		"use latest": {
 			cmdOpts: &commandOptions{
@@ -232,17 +243,19 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
-			expected:  "2020-04-11",
-			shouldErr: false,
+			now:        time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
+			expected:   "2020-04-11",
+			shouldErr:  false,
+			shouldWarn: false,
 		},
 		"no latest found": {
 			cmdOpts: &commandOptions{
 				latest: true,
 			},
-			files:     []string{},
-			now:       time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
-			shouldErr: true,
+			files:      []string{},
+			now:        time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
+			shouldErr:  true,
+			shouldWarn: false,
 		},
 		"default to today": {
 			cmdOpts: &commandOptions{},
@@ -251,22 +264,44 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
-			expected:  "2020-04-15",
-			shouldErr: false,
+			now:        time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
+			expected:   "2020-04-15",
+			shouldErr:  false,
+			shouldWarn: false,
+		},
+		"should warn on latest": {
+			cmdOpts: &commandOptions{
+				latest: true,
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:        time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
+			expected:   "2020-04-11",
+			shouldErr:  false,
+			shouldWarn: true,
+			warnThresh: 2,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			// setup
 			getFiles := func(dir string) ([]string, error) {
 				return test.files, nil
 			}
-			err := setDateOpt(test.cmdOpts, templateOpts, getFiles, test.now)
+			if test.shouldWarn {
+				templateOpts.TemplateFileCountThresh = test.warnThresh
+			}
+
+			shouldWarn, err := setDateOpt(test.cmdOpts, templateOpts, getFiles, test.now)
 			if test.shouldErr {
 				require.Error(t, err)
 				return
 			}
+			require.Equal(t, test.shouldWarn, shouldWarn)
 			require.NoError(t, err)
 			require.Equal(t, test.expected, test.cmdOpts.date)
 		})
@@ -277,11 +312,13 @@ func TestSetCopyDateOpt(t *testing.T) {
 	templateOpts := templatetest.GetOpts()
 
 	type testCase struct {
-		cmdOpts   *commandOptions
-		files     []string
-		now       time.Time
-		expected  string
-		shouldErr bool
+		cmdOpts    *commandOptions
+		files      []string
+		now        time.Time
+		expected   string
+		shouldErr  bool
+		shouldWarn bool
+		warnThresh int
 	}
 
 	tests := map[string]testCase{
@@ -295,8 +332,9 @@ func TestSetCopyDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			shouldErr: true,
+			now:        time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			shouldErr:  true,
+			shouldWarn: false,
 		},
 		"use copyDate": {
 			cmdOpts: &commandOptions{
@@ -307,9 +345,10 @@ func TestSetCopyDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "2020-04-11",
-			shouldErr: false,
+			now:        time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:   "2020-04-11",
+			shouldErr:  false,
+			shouldWarn: false,
 		},
 		"use copyDaysBack": {
 			cmdOpts: &commandOptions{
@@ -320,9 +359,10 @@ func TestSetCopyDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "2020-04-10",
-			shouldErr: false,
+			now:        time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:   "2020-04-10",
+			shouldErr:  false,
+			shouldWarn: false,
 		},
 		"default to latest": {
 			cmdOpts: &commandOptions{},
@@ -331,29 +371,50 @@ func TestSetCopyDateOpt(t *testing.T) {
 				"2020-04-10.txt",
 				"2020-04-09.txt",
 			},
-			now:       time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
-			expected:  "2020-04-11",
-			shouldErr: false,
+			now:        time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
+			expected:   "2020-04-11",
+			shouldErr:  false,
+			shouldWarn: false,
 		},
 		"no latest found": {
-			cmdOpts:   &commandOptions{},
-			files:     []string{},
-			now:       time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
-			expected:  "",
-			shouldErr: false,
+			cmdOpts:    &commandOptions{},
+			files:      []string{},
+			now:        time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
+			expected:   "",
+			shouldErr:  false,
+			shouldWarn: false,
+		},
+		"should warn on latest": {
+			cmdOpts: &commandOptions{},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:        time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
+			expected:   "2020-04-11",
+			shouldErr:  false,
+			shouldWarn: true,
+			warnThresh: 2,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			// setup
 			getFiles := func(dir string) ([]string, error) {
 				return test.files, nil
 			}
-			err := setCopyDateOpt(test.cmdOpts, templateOpts, getFiles, test.now)
+			if test.shouldWarn {
+				templateOpts.TemplateFileCountThresh = test.warnThresh
+			}
+
+			shouldWarn, err := setCopyDateOpt(test.cmdOpts, templateOpts, getFiles, test.now)
 			if test.shouldErr {
 				require.Error(t, err)
 				return
 			}
+			require.Equal(t, test.shouldWarn, shouldWarn)
 			require.NoError(t, err)
 			require.Equal(t, test.expected, test.cmdOpts.copyDate)
 		})

--- a/cmd/open/open_test.go
+++ b/cmd/open/open_test.go
@@ -121,7 +121,6 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-09.txt",
 			},
 			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "",
 			shouldErr: true,
 		},
 		"multiple mutually exclusive flags: date and tomorrow set": {
@@ -135,7 +134,6 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-09.txt",
 			},
 			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "",
 			shouldErr: true,
 		},
 		"multiple mutually exclusive flags: date and latest set": {
@@ -149,7 +147,6 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-09.txt",
 			},
 			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "",
 			shouldErr: true,
 		},
 		"multiple mutually exclusive flags: daysBack and tomorrow set": {
@@ -163,7 +160,6 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-09.txt",
 			},
 			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "",
 			shouldErr: true,
 		},
 		"multiple mutually exclusive flags: daysBack and latest set": {
@@ -177,7 +173,6 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-09.txt",
 			},
 			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "",
 			shouldErr: true,
 		},
 		"multiple mutually exclusive flags: tomorrow and latest set": {
@@ -191,7 +186,6 @@ func TestSetDateOpt(t *testing.T) {
 				"2020-04-09.txt",
 			},
 			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "",
 			shouldErr: true,
 		},
 		"use date": {
@@ -246,6 +240,25 @@ func TestSetDateOpt(t *testing.T) {
 			expected:  "2020-04-11",
 			shouldErr: false,
 		},
+		"no latest found": {
+			cmdOpts: &commandOptions{
+				latest: true,
+			},
+			files:     []string{},
+			now:       time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
+			shouldErr: true,
+		},
+		"default to today": {
+			cmdOpts: &commandOptions{},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
+			expected:  "2020-04-15",
+			shouldErr: false,
+		},
 	}
 
 	for name, test := range tests {
@@ -260,6 +273,92 @@ func TestSetDateOpt(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, test.expected, test.cmdOpts.date)
+		})
+	}
+}
+
+func TestSetCopyDateOpt(t *testing.T) {
+	templateOpts := templatetest.GetOpts()
+
+	type testCase struct {
+		cmdOpts   *commandOptions
+		files     []string
+		now       time.Time
+		expected  string
+		shouldErr bool
+	}
+
+	tests := map[string]testCase{
+		"multiple mutually exclusive flags: copyDate and copyDaysBack set": {
+			cmdOpts: &commandOptions{
+				copyDate:     "2020-04-11",
+				copyDaysBack: 2,
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			shouldErr: true,
+		},
+		"use copyDate": {
+			cmdOpts: &commandOptions{
+				copyDate: "2020-04-11",
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "2020-04-11",
+			shouldErr: false,
+		},
+		"use copyDaysBack": {
+			cmdOpts: &commandOptions{
+				copyDaysBack: 2,
+			},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected:  "2020-04-10",
+			shouldErr: false,
+		},
+		"default to latest": {
+			cmdOpts: &commandOptions{},
+			files: []string{
+				"2020-04-11.txt",
+				"2020-04-10.txt",
+				"2020-04-09.txt",
+			},
+			now:       time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
+			expected:  "2020-04-11",
+			shouldErr: false,
+		},
+		"no latest found": {
+			cmdOpts:   &commandOptions{},
+			files:     []string{},
+			now:       time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
+			shouldErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			getFiles := func(dir string) ([]string, error) {
+				return test.files, nil
+			}
+			err := setCopyDateOpt(test.cmdOpts, templateOpts, getFiles, test.now)
+			if test.shouldErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, test.cmdOpts.copyDate)
 		})
 	}
 }

--- a/cmd/open/open_test.go
+++ b/cmd/open/open_test.go
@@ -12,43 +12,43 @@ func TestGetLatestTemplateFile(t *testing.T) {
 	opts := templatetest.GetOpts()
 
 	type testCase struct {
-		files    []string
-		now      time.Time
-		expected string
-		found    bool
+		files            []string
+		now              time.Time
+		expectedLatest   string
+		expectedNumFound int
 	}
 
 	tests := map[string]testCase{
 		"empty directory": {
-			files:    []string{},
-			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected: "",
-			found:    false,
+			files:            []string{},
+			now:              time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expectedLatest:   "",
+			expectedNumFound: 0,
 		},
 		"no timestamped template files": {
 			files: []string{
 				"archive-Dec2019.txt",
 				"archive-2019-11-01.txt",
 			},
-			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected: "",
-			found:    false,
+			now:              time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expectedLatest:   "",
+			expectedNumFound: 0,
 		},
 		"single template file in future": {
 			files: []string{
 				"2020-04-13.txt",
 			},
-			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected: "",
-			found:    false,
+			now:              time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expectedLatest:   "",
+			expectedNumFound: 1,
 		},
 		"single template file": {
 			files: []string{
 				"2020-03-11.txt",
 			},
-			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected: "2020-03-11.txt",
-			found:    true,
+			now:              time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expectedLatest:   "2020-03-11.txt",
+			expectedNumFound: 1,
 		},
 		"multiple template files": {
 			files: []string{
@@ -56,9 +56,9 @@ func TestGetLatestTemplateFile(t *testing.T) {
 				"2020-03-12.txt",
 				"2020-03-13.txt",
 			},
-			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected: "2020-03-13.txt",
-			found:    true,
+			now:              time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expectedLatest:   "2020-03-13.txt",
+			expectedNumFound: 3,
 		},
 		"multiple template files with one in future": {
 			files: []string{
@@ -66,9 +66,9 @@ func TestGetLatestTemplateFile(t *testing.T) {
 				"2020-04-12.txt",
 				"2020-04-13.txt",
 			},
-			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected: "2020-04-12.txt",
-			found:    true,
+			now:              time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expectedLatest:   "2020-04-12.txt",
+			expectedNumFound: 3,
 		},
 		"mix of timestamped template files and other files": {
 			files: []string{
@@ -79,17 +79,17 @@ func TestGetLatestTemplateFile(t *testing.T) {
 				"2020-03-13.txt",
 				"archive_April2020",
 			},
-			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected: "2020-03-13.txt",
-			found:    true,
+			now:              time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expectedLatest:   "2020-03-13.txt",
+			expectedNumFound: 3,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			latest, found := getLatestTemplateFile(test.files, test.now, opts.File)
-			require.Equal(t, test.found, found)
-			require.Equal(t, test.expected, latest)
+			latest, numFound := getLatestTemplateFile(test.files, test.now, opts.File)
+			require.Equal(t, test.expectedLatest, latest)
+			require.Equal(t, test.expectedNumFound, numFound)
 		})
 	}
 }

--- a/cmd/open/open_test.go
+++ b/cmd/open/open_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetLatestFile(t *testing.T) {
+func TestGetLatestTemplateFile(t *testing.T) {
 	opts := templatetest.GetOpts()
 
 	type testCase struct {
@@ -87,7 +87,7 @@ func TestGetLatestFile(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			latest, found := getLatestFile(test.files, test.now, opts.File)
+			latest, found := getLatestTemplateFile(test.files, test.now, opts.File)
 			require.Equal(t, test.found, found)
 			require.Equal(t, test.expected, latest)
 		})

--- a/cmd/open/open_test.go
+++ b/cmd/open/open_test.go
@@ -12,43 +12,43 @@ func TestGetLatestFile(t *testing.T) {
 	opts := templatetest.GetOpts()
 
 	type testCase struct {
-		files     []string
-		now       time.Time
-		expected  string
-		shouldErr bool
+		files    []string
+		now      time.Time
+		expected string
+		found    bool
 	}
 
 	tests := map[string]testCase{
 		"empty directory": {
-			files:     []string{},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "",
-			shouldErr: true,
+			files:    []string{},
+			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected: "",
+			found:    false,
 		},
 		"no timestamped template files": {
 			files: []string{
 				"archive-Dec2019.txt",
 				"archive-2019-11-01.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "",
-			shouldErr: true,
+			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected: "",
+			found:    false,
 		},
 		"single template file in future": {
 			files: []string{
 				"2020-04-13.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "",
-			shouldErr: true,
+			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected: "",
+			found:    false,
 		},
 		"single template file": {
 			files: []string{
 				"2020-03-11.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "2020-03-11.txt",
-			shouldErr: false,
+			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected: "2020-03-11.txt",
+			found:    true,
 		},
 		"multiple template files": {
 			files: []string{
@@ -56,9 +56,9 @@ func TestGetLatestFile(t *testing.T) {
 				"2020-03-12.txt",
 				"2020-03-13.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "2020-03-13.txt",
-			shouldErr: false,
+			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected: "2020-03-13.txt",
+			found:    true,
 		},
 		"multiple template files with one in future": {
 			files: []string{
@@ -66,9 +66,9 @@ func TestGetLatestFile(t *testing.T) {
 				"2020-04-12.txt",
 				"2020-04-13.txt",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "2020-04-12.txt",
-			shouldErr: false,
+			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected: "2020-04-12.txt",
+			found:    true,
 		},
 		"mix of timestamped template files and other files": {
 			files: []string{
@@ -79,20 +79,16 @@ func TestGetLatestFile(t *testing.T) {
 				"2020-03-13.txt",
 				"archive_April2020",
 			},
-			now:       time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
-			expected:  "2020-03-13.txt",
-			shouldErr: false,
+			now:      time.Date(2020, 4, 12, 0, 0, 0, 0, time.UTC),
+			expected: "2020-03-13.txt",
+			found:    true,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			latest, err := getLatestFile(test.files, test.now, opts.File)
-			if test.shouldErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
+			latest, found := getLatestFile(test.files, test.now, opts.File)
+			require.Equal(t, test.found, found)
 			require.Equal(t, test.expected, latest)
 		})
 	}
@@ -343,7 +339,8 @@ func TestSetCopyDateOpt(t *testing.T) {
 			cmdOpts:   &commandOptions{},
 			files:     []string{},
 			now:       time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC),
-			shouldErr: true,
+			expected:  "",
+			shouldErr: false,
 		},
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dkaslovsky/textnote/cmd/archive"
 	"github.com/dkaslovsky/textnote/cmd/config"
+	"github.com/dkaslovsky/textnote/cmd/initialize"
 	"github.com/dkaslovsky/textnote/cmd/open"
 	pkgconf "github.com/dkaslovsky/textnote/pkg/config"
 	"github.com/spf13/cobra"
@@ -28,6 +29,7 @@ func Run(name string, version string) error {
 		open.CreateOpenCmd(),
 		archive.CreateArchiveCmd(),
 		config.CreateConfigCmd(),
+		initialize.CreateInitCmd(),
 	)
 
 	setVersion(cmd, version)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dkaslovsky/textnote
 
-go 1.15
+go 1.16
 
 require (
 	github.com/ilyakaznacheev/cleanenv v1.2.5

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.16
 
 require (
 	github.com/ilyakaznacheev/cleanenv v1.2.5
-	github.com/imdario/mergo v0.3.11
+	github.com/imdario/mergo v0.3.12
 	github.com/pkg/errors v0.9.1
-	github.com/spf13/cobra v1.1.1
+	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/ilyakaznacheev/cleanenv v1.2.5 h1:/SlcF9GaIvefWqFJzsccGG/NJdoaAwb7Mm7ImzhO3DM=
 github.com/ilyakaznacheev/cleanenv v1.2.5/go.mod h1:/i3yhzwZ3s7hacNERGFwvlhwXMDcaqwIzmayEhbRplk=
-github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
-github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
+github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
@@ -160,8 +160,8 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
-github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
+github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
+github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -295,7 +295,6 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/main.go
+++ b/main.go
@@ -12,6 +12,8 @@ const name = "textnote"
 var version string // set by build ldflags
 
 func main() {
+	log.SetFlags(0)
+
 	err := config.EnsureAppDir()
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -14,12 +14,7 @@ var version string // set by build ldflags
 func main() {
 	log.SetFlags(0)
 
-	err := config.EnsureAppDir()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = config.CreateIfNotExists()
+	err := config.InitApp()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -251,3 +251,16 @@ func DescribeEnvVars() string {
 func GetConfigFilePath() string {
 	return filepath.Join(appDir, fileName)
 }
+
+// InitApp initializes the application by ensuring the necessary directories and files exist
+func InitApp() error {
+	err := EnsureAppDir()
+	if err != nil {
+		return err
+	}
+	err = CreateIfNotExists()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -157,7 +156,7 @@ func CreateIfNotExists() error {
 	if err != nil {
 		return errors.Wrap(err, "unable to generate config file")
 	}
-	err = ioutil.WriteFile(configPath, yml, 0644)
+	err = os.WriteFile(configPath, yml, 0644)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("unable to create configuration file: [%s]", configPath))
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,12 +27,13 @@ var (
 
 // Opts are options that configure the application
 type Opts struct {
-	AppDir  string      `yaml:"-"` // AppDir is always read from the environment and is not written to file
-	Header  HeaderOpts  `yaml:"header"`
-	Section SectionOpts `yaml:"section"`
-	File    FileOpts    `yaml:"file"`
-	Archive ArchiveOpts `yaml:"archive"`
-	Cli     CliOpts     `yaml:"cli"`
+	AppDir                  string      `yaml:"-"` // AppDir is always read from the environment and is not written to file
+	Header                  HeaderOpts  `yaml:"header"`
+	Section                 SectionOpts `yaml:"section"`
+	File                    FileOpts    `yaml:"file"`
+	Archive                 ArchiveOpts `yaml:"archive"`
+	Cli                     CliOpts     `yaml:"cli"`
+	TemplateFileCountThresh int         `yaml:"templateFileCountTresh" env:"TEXTNOTE_TEMPLATE_FILE_COUNT_THRESH" env-description:"threshold for warning too many template files"`
 }
 
 // HeaderOpts are options for configuring the header of a note
@@ -111,6 +112,7 @@ func getDefaultOpts() Opts {
 		Cli: CliOpts{
 			TimeFormat: "2006-01-02",
 		},
+		TemplateFileCountThresh: 90,
 	}
 }
 
@@ -225,6 +227,11 @@ func ValidateOpts(opts Opts) error {
 	// validate the file cursor line is not negative
 	if opts.File.CursorLine < 0 {
 		return errors.New("cursor line must not be negative")
+	}
+
+	// validate threshold for warning on too many template files is larger than archive after days
+	if opts.TemplateFileCountThresh <= opts.Archive.AfterDays {
+		return errors.New("template file count threshold must be larger than archive after days")
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -119,6 +119,22 @@ func TestValidateOpts(t *testing.T) {
 		err := ValidateOpts(opts)
 		require.NoError(t, err)
 	})
+
+	t.Run("template file count threshold not greater than archive after days should error", func(t *testing.T) {
+		opts := getTestOpts()
+		opts.Archive.AfterDays = 100
+		opts.TemplateFileCountThresh = 100
+		err := ValidateOpts(opts)
+		require.Error(t, err)
+	})
+
+	t.Run("template file count threshold greater than archive after days should not error", func(t *testing.T) {
+		opts := getTestOpts()
+		opts.Archive.AfterDays = 100
+		opts.TemplateFileCountThresh = 101
+		err := ValidateOpts(opts)
+		require.NoError(t, err)
+	})
 }
 
 func getTestOpts() Opts {

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -3,7 +3,6 @@ package template
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"time"
@@ -92,7 +91,7 @@ func (t *Template) DeleteSectionContents(sectionName string) error {
 
 // Load populates a Template from the contents of a reader
 func (t *Template) Load(r io.Reader) error {
-	raw, err := ioutil.ReadAll(r)
+	raw, err := io.ReadAll(r)
 	if err != nil {
 		return errors.Wrap(err, "error loading template")
 	}

--- a/pkg/template/templatetest/templatetest.go
+++ b/pkg/template/templatetest/templatetest.go
@@ -50,6 +50,7 @@ func GetOpts() config.Opts {
 		Cli: config.CliOpts{
 			TimeFormat: "2006-01-02",
 		},
+		TemplateFileCountThresh: 90,
 	}
 
 	err := config.ValidateOpts(opts)


### PR DESCRIPTION
- Add capability to find most recently dated ("latest") template file
  - Display message warning if number of template files searched exceeds threshold
  - Add threshold to configuration
- Add `--latest` flag to `open` command to open latest existing file
- Change copy date default to use latest, fixing a bug where it defaulted to the previous day which might not exist 
- Add tests for `open` command
- Add `init` command to more cleanly create application directories and configuration files
- Add flags to `config` command to show active configuration and configuration file
- Add `update` subcommand `config` to overwrite configuration file with active configuration
- Upgrade to Go 1.16
  - Deprecate use of `io/ioutil`
  - Update CI configuration
- Update documentation in README